### PR TITLE
Vowel and consonant fix

### DIFF
--- a/src/main/java/de/fxnn/readablehash/ReadableHash.java
+++ b/src/main/java/de/fxnn/readablehash/ReadableHash.java
@@ -8,9 +8,9 @@ import static java.lang.Character.toLowerCase;
 
 public class ReadableHash {
 
-  static final char[] CONSONANTS = "BCDFGHKLMNPQRSTVWXYZ".toCharArray();
+  static final char[] CONSONANTS = "BCDFGHJKLMNPQRSTVWXZ".toCharArray();
 
-  static final char[] VOWELS = "AEIJOU".toCharArray();
+  static final char[] VOWELS = "AEIOUY".toCharArray();
 
   static final int MIN_SYLLABLE_COUNT_PER_WORD = 1;
 


### PR DESCRIPTION
Hi! I love your hash library, just noticed it produces some difficult to pronounce hashes, so here's a fix I hope you'll accept to your master branch. :)

The fix:

The letter 'J' is not a vowel, thus moved it to consonants. Also the letter 'Y' is widely considered as a vowel in english language, moved it to vowels. Now the hashes have better flow when reading.
